### PR TITLE
Fix equality and hash code of CacheableInvocation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-    <PropertyGroup>
-        <WithoutCrossCompile>True</WithoutCrossCompile>
-    </PropertyGroup>
+	<PropertyGroup>
+		<WithoutCrossCompile Condition="'$(GITHUB_ACTION)' != '' OR '$(LGTM_SRC)' != ''">True</WithoutCrossCompile>
+	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <WithoutCrossCompile Condition="'$(GITHUB_ACTION)' != '' OR '$(LGTM_SRC)' != ''">True</WithoutCrossCompile>
+        <WithoutCrossCompile>True</WithoutCrossCompile>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup>
-		<WithoutCrossCompile Condition="'$(GITHUB_ACTION)' != '' OR '$(LGTM_SRC)' != ''">True</WithoutCrossCompile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <WithoutCrossCompile Condition="'$(GITHUB_ACTION)' != '' OR '$(LGTM_SRC)' != ''">True</WithoutCrossCompile>
+    </PropertyGroup>
 </Project>

--- a/Dynamitey/CacheableInvocation.cs
+++ b/Dynamitey/CacheableInvocation.cs
@@ -169,7 +169,7 @@ namespace Dynamitey
             if (ReferenceEquals(this, other)) return true;
             return base.Equals(other) 
                 && other._argCount == _argCount 
-                && (_argNames ?? Array.Empty<string>()).SequenceEqual(other._argNames ?? Array.Empty<string>())
+                && (_argNames ?? new string[] { }).SequenceEqual(other._argNames ?? new string[] { })
                 && other._staticContext.Equals(_staticContext)
                 && Equals(other._context, _context) 
                 && other._convertExplicit.Equals(_convertExplicit)

--- a/Dynamitey/CacheableInvocation.cs
+++ b/Dynamitey/CacheableInvocation.cs
@@ -6,6 +6,8 @@ using Dynamitey.Internal.Optimization;
 using Microsoft.CSharp.RuntimeBinder;
 using System.Reflection;
 using Dynamitey.Internal.Compat;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Dynamitey
 {
@@ -167,7 +169,7 @@ namespace Dynamitey
             if (ReferenceEquals(this, other)) return true;
             return base.Equals(other) 
                 && other._argCount == _argCount 
-                && Equals(other._argNames, _argNames) 
+                && ((IStructuralEquatable)_argNames).Equals(other._argNames, EqualityComparer<string>.Default) 
                 && other._staticContext.Equals(_staticContext)
                 && Equals(other._context, _context) 
                 && other._convertExplicit.Equals(_convertExplicit)
@@ -200,7 +202,7 @@ namespace Dynamitey
             {
                 int result = base.GetHashCode();
                 result = (result*397) ^ _argCount;
-                result = (result*397) ^ (_argNames != null ? _argNames.GetHashCode() : 0);
+                result = (result*397) ^ (_argNames != null ? ((IStructuralEquatable)_argNames).GetHashCode(EqualityComparer<string>.Default) : 0);
                 result = (result*397) ^ _staticContext.GetHashCode();
                 result = (result*397) ^ (_context != null ? _context.GetHashCode() : 0);
                 result = (result*397) ^ _convertExplicit.GetHashCode();

--- a/Dynamitey/CacheableInvocation.cs
+++ b/Dynamitey/CacheableInvocation.cs
@@ -169,7 +169,7 @@ namespace Dynamitey
             if (ReferenceEquals(this, other)) return true;
             return base.Equals(other) 
                 && other._argCount == _argCount 
-                && ((IStructuralEquatable)_argNames).Equals(other._argNames, EqualityComparer<string>.Default) 
+                && (_argNames ?? Array.Empty<string>()).SequenceEqual(other._argNames ?? Array.Empty<string>())
                 && other._staticContext.Equals(_staticContext)
                 && Equals(other._context, _context) 
                 && other._convertExplicit.Equals(_convertExplicit)

--- a/Tests/Invoke.cs
+++ b/Tests/Invoke.cs
@@ -1365,7 +1365,18 @@ namespace Dynamitey.Tests
             Assert.AreEqual("Two", Dynamic.GetMemberNames(tDict, dynamicOnly: true).Single());
         }
 
+        [Test]
+        public void TestCachedInvocationEquality()
+        {
+            var tCachedIvnocation1 = new CacheableInvocation(InvocationKind.InvokeMember, "Func", argCount: 2,
+                                                            argNames: new[] { "two" });
 
+            var tCachedIvnocation2 = new CacheableInvocation(InvocationKind.InvokeMember, "Func", argCount: 2,
+                                                            argNames: new[] { "two" });
+
+            Assert.AreEqual(tCachedIvnocation1.GetHashCode(), tCachedIvnocation2.GetHashCode());
+            Assert.AreEqual(tCachedIvnocation1, tCachedIvnocation2);
+        }
 
 
         private DynamicObject CreateMock(ExpressionType op)


### PR DESCRIPTION
Previous version was not structurally comparing the _argNames array so instances with the same arg names were comparing different. Added fix and test.